### PR TITLE
exposing manifest parsers 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
 (function() {
-  module.exports = require('./lib/apkreader');
+  module.exports = {
+    apkreader: require('./lib/apkreader'),
+    BinaryXmlParser: require('./lib/apkreader/parser/binaryxml'),
+    ManifestParser: require('./lib/apkreader/parser/manifest')
+  }
 }).call(this);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 (function() {
   module.exports = {
-    apkreader: require('./lib/apkreader'),
+    ApkReader: require('./lib/apkreader'),
     BinaryXmlParser: require('./lib/apkreader/parser/binaryxml'),
     ManifestParser: require('./lib/apkreader/parser/manifest')
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-apk-parser",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Extracts information from APK files.",
   "keywords": [
     "adb",


### PR DESCRIPTION
In situations where you might need to extract multiple packages across platforms, it is more useful to be able to parse the manifest itself with the assumption that the apk has already been unzipped. This change makes it possible to create a manifest parser without it being hidden behind the apkReader. 